### PR TITLE
Moves specials and special vals into the Element struct

### DIFF
--- a/TheElements-dev/jni/app.c
+++ b/TheElements-dev/jni/app.c
@@ -39,7 +39,7 @@ float a_oldY[MAX_POINTS];
 short a_xVel[MAX_POINTS];
 short a_yVel[MAX_POINTS];
 char a_heat[MAX_POINTS];
-char* a_specialVals[MAX_POINTS];
+int* a_specialVals[MAX_POINTS];
 struct Element* a_element[MAX_POINTS];
 char a_frozen[MAX_POINTS];
 char a_hasMoved[MAX_POINTS];

--- a/TheElements-dev/jni/app.h
+++ b/TheElements-dev/jni/app.h
@@ -49,8 +49,8 @@ extern "C" {
         char red, green, blue;
 
         //Properties
-        char* specials;
-        char* specialVals;
+        int specials[MAX_SPECIALS];
+        int specialVals[MAX_SPECIALS];
         char* collisions;  // Only for customs
         char base; //Only for customs
         char density;
@@ -89,7 +89,7 @@ extern "C" {
     extern short a_xVel[];
     extern short a_yVel[];
     extern char a_heat[];
-    extern char* a_specialVals[];
+    extern int* a_specialVals[];
     extern struct Element* a_element[];
     extern char a_frozen[];
     extern char a_hasMoved[];

--- a/TheElements-dev/jni/elementproperties.c
+++ b/TheElements-dev/jni/elementproperties.c
@@ -120,7 +120,7 @@ char baseState[] = {0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 2, 1, 0, 1, 0, 0, 0, 1, 0, 1, 
  */
 //Defines the special for each base element
 
-signed char baseSpecial[][MAX_SPECIALS] =
+int baseSpecial[][MAX_SPECIALS] =
 {
     {SPECIAL_SPAWN, SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE}, //Spawn
     {SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE, SPECIAL_NONE}, //Drag
@@ -158,7 +158,7 @@ signed char baseSpecial[][MAX_SPECIALS] =
 
 
 //Defines the special value for each base element
-char baseSpecialValue[][MAX_SPECIALS] =
+int baseSpecialValue[][MAX_SPECIALS] =
 {
     {0,0,0,0,0,0}, //TODO: Add the element names next to all of these columns
     {0,0,0,0,0,0},

--- a/TheElements-dev/jni/elementproperties.h
+++ b/TheElements-dev/jni/elementproperties.h
@@ -78,9 +78,9 @@ extern char baseState[];
  *              4 = Explode; Explosiveness
  */
 //Defines the special for each base element
-extern signed char baseSpecial[][MAX_SPECIALS];
+extern int baseSpecial[][MAX_SPECIALS];
 //Defines the special value for each base element
-extern char baseSpecialValue[][MAX_SPECIALS];
+extern int baseSpecialValue[][MAX_SPECIALS];
 //Defines the inertia of each element
 extern char baseInertia[];
 //Defines the starting temp of the element (-1 = atmosphere)

--- a/TheElements-dev/jni/macros.h
+++ b/TheElements-dev/jni/macros.h
@@ -11,6 +11,9 @@
 #ifndef MACROS_H_INCLUDED
 #define MACROS_H_INCLUDED
 
+/*
+ * CONSTANTS
+ */
 #define MAX_POINTS 100000
 #define NUM_BASE_ELEMENTS 32
 #define MAX_SPECIALS 6
@@ -103,7 +106,7 @@
 #define ELECTRIC_XN     4 // 0100
 #define ELECTRIC_YN     8 // 1000
 #define ELECTRIC_WAIT  16 //10000
-#define SPECIAL_VAL_UNSET 255
+#define SPECIAL_VAL_UNSET -1
 
 //Sample log call
 //__android_log_write(ANDROID_LOG_INFO, "TheElements", "Hi!");

--- a/TheElements-dev/jni/points.c
+++ b/TheElements-dev/jni/points.c
@@ -165,12 +165,12 @@ void changeHeat(char *heat, int heatChange)
 }
 
 //Function to check if a particle has a given special
-char hasSpecial(int tempParticle, int special)
+int hasSpecial(int tempParticle, int special)
 {
-    char* specials;
-    long start = a_element[tempParticle]->specials;
-    long end = start + MAX_SPECIALS;
-    for(specials = start; specials < end; ++specials)
+    int* specials;
+    int* start = specials = a_element[tempParticle]->specials;
+    int* end = start + MAX_SPECIALS;
+    for(; specials < end; ++specials)
     {
         if (*specials == special) return TRUE;
     }
@@ -179,16 +179,16 @@ char hasSpecial(int tempParticle, int special)
 
 //Gets a particle's special value
 //WARNING: Just gets the first special of that type it finds
-char getParticleSpecialVal(int tempParticle, int special)
+int getParticleSpecialVal(int tempParticle, int special)
 {
-    char * specials;
-    long start =  a_element[tempParticle]->specials;
-    long end = start + MAX_SPECIALS;
-    for (specials = start; specials < end; ++specials)
+    int* specials;
+    int* start = specials = a_element[tempParticle]->specials;
+    int* end = start + MAX_SPECIALS;
+    for (; specials < end; ++specials)
     {
         if (*specials == special)
         {
-            return a_specialVals[tempParticle][(long)specials-start];
+            return a_specialVals[tempParticle][specials-start];
         }
     }
 
@@ -196,39 +196,41 @@ char getParticleSpecialVal(int tempParticle, int special)
 }
 //Sets a particle's special value
 //WARNING: Just sets the first special of that type it finds
-void setParticleSpecialVal(int tempParticle, int special, char val)
+void setParticleSpecialVal(int tempParticle, int special, int val)
 {
-    char * specials;
-    long start = a_element[tempParticle]->specials;
-    long end = start + MAX_SPECIALS;
-    for (specials = start; specials < end; ++specials)
+    int* specials;
+    int* start = specials = a_element[tempParticle]->specials;
+    int* end = start + MAX_SPECIALS;
+    for (; specials < end; ++specials)
     {
         if (*specials == special)
         {
-            a_specialVals[tempParticle][(long)specials-start] = val;
+            a_specialVals[tempParticle][specials-start] = val;
         }
     }
 }
 //Gets an element's special value
 //WARNING: Just gets the first special of that type it finds
-char getElementSpecialVal(struct Element* tempElement, int special)
+int getElementSpecialVal(struct Element* tempElement, int special)
 {
-    char * specials;
-    long start = tempElement->specials;
-    long end = start + MAX_SPECIALS;
-    for (specials = start; specials < end; ++specials)
+    int* specials;
+    int* start = specials = tempElement->specials;
+    int* end = start + MAX_SPECIALS;
+    for (; specials < end; ++specials)
     {
         if (*specials == special)
         {
-            return tempElement->specialVals[(long)specials-start];
+            return tempElement->specialVals[specials-start];
         }
     }
+
+    return SPECIAL_VAL_UNSET;
 }
 
 void clearSpecialVals(int tempParticle)
 {
-    char* specialVals = a_specialVals[tempParticle];
-    long end = (long)specialVals  + MAX_SPECIALS;
+    int* specialVals = a_specialVals[tempParticle];
+    int* end = specialVals + MAX_SPECIALS;
     for ( ; specialVals < end; ++specialVals)
     {
         *specialVals = SPECIAL_VAL_UNSET;

--- a/TheElements-dev/jni/points.h
+++ b/TheElements-dev/jni/points.h
@@ -23,10 +23,10 @@ void clearBitmapColor(int xCoord, int yCoord);
 void createBitmapFromPoints(void);
 void unFreezeParticles(int xCoord, int yCoord);
 void changeHeat(char *heat, int heatChange);
-char hasSpecial(int tempParticle, int special);
-char getParticleSpecialVal(int tempParticle, int special);
-void setParticleSpecialVal(int tempParticle, int special, char val);
-char getElementSpecialVal(struct Element* tempElement, int special);
+int hasSpecial(int tempParticle, int special);
+int getParticleSpecialVal(int tempParticle, int special);
+void setParticleSpecialVal(int tempParticle, int special, int val);
+int getElementSpecialVal(struct Element* tempElement, int special);
 void clearSpecialVals(int tempParticle);
 
 #endif //!POINTS_H_INCLUDED

--- a/TheElements-dev/jni/saveload.c
+++ b/TheElements-dev/jni/saveload.c
@@ -207,9 +207,8 @@ char loadStateLogicV0(FILE* fp)
             if((charsRead = fscanf(fp, "%d", &tempElement->inertia)) == EOF || charsRead < 1) {return FALSE;}
 
             int j;
-            char special, specialVal, collision;
-            tempElement->specials = malloc (MAX_SPECIALS * sizeof(char));
-            tempElement->specialVals = malloc (MAX_SPECIALS * sizeof(char));
+            char collision;
+            int special, specialVal;
             tempElement->collisions = malloc (NUM_BASE_ELEMENTS * sizeof(char));
             // Load collisions
             for (j = 0; j < NUM_BASE_ELEMENTS; j++)
@@ -725,8 +724,6 @@ char loadCustomElement(char* loadLoc)
 
     // Allocate collisions and specials related arrays
     tempCustom->collisions = malloc(NUM_BASE_ELEMENTS * sizeof(char));
-    tempCustom->specials = malloc(MAX_SPECIALS*sizeof(char));
-    tempCustom->specialVals = malloc(MAX_SPECIALS*sizeof(char));
 
     // Read in the collisions header, with a reasonable fallback
     int numCollisionsToRead;

--- a/TheElements-dev/jni/setup.c
+++ b/TheElements-dev/jni/setup.c
@@ -117,12 +117,8 @@ void elementSetup()
             tempElement->fallVel = baseFallVel[i];
             tempElement->density = baseDensity[i];
             tempElement->state = baseState[i];
-            tempElement->specials = baseSpecial[i];
-            tempElement->specialVals = (char*) malloc(MAX_SPECIALS * sizeof(char));
-            for(j = 0; j < MAX_SPECIALS; j++)
-            {
-                tempElement->specialVals[j] = baseSpecialValue[i][j];
-            }
+            memcpy(tempElement->specials, baseSpecial[i], MAX_SPECIALS * sizeof(int));
+            memcpy(tempElement->specialVals, baseSpecialValue[i], MAX_SPECIALS * sizeof(int));
             tempElement->inertia = baseInertia[i];
             tempElement->startingTemp = baseStartingTemp[i];
             tempElement->highestTemp = baseHighestTemp[i];
@@ -152,7 +148,6 @@ void particleSetup()
     int i;
     for(i = 0; i < MAX_POINTS; i++)
     {
-        
-        a_specialVals[i] = (char*) malloc(MAX_SPECIALS * sizeof(char));
+        a_specialVals[i] = (int*) malloc(MAX_SPECIALS * sizeof(int));
     }
 }

--- a/TheElements-dev/jni/update.c
+++ b/TheElements-dev/jni/update.c
@@ -290,22 +290,11 @@ int updateSpecials(int index)
     char specialLoopDone = FALSE;
     for (i = MAX_SPECIALS; i != 0; i--)
     {
-        if (!tempElement->specials)
-        {
-            __android_log_write(ANDROID_LOG_ERROR, "LOG", "Null specials array!");
-            break;
-        }
-        /*
-          char buffer[256];
-          sprintf(buffer, "Processing special: %d, val: %d", i, tempElement->specials[i]);
-          __android_log_write(ANDROID_LOG_INFO, "LOG", buffer);
-        */
-
         if(tempElement->specials[MAX_SPECIALS-i] == SPECIAL_NONE)
         {
             return shouldResolveHeatChanges;
         }
-        switch((int)tempElement->specials[MAX_SPECIALS-i])
+        switch(tempElement->specials[MAX_SPECIALS-i])
         {
             //Spawn
         case SPECIAL_SPAWN:


### PR DESCRIPTION
This speeds up the specials loop a bit, and especially is useful
for particles that have no specials, since cache locality means
no costly memory lookups have to take place for something that
doesn't have an effect in the end.
