### PR TITLE
Fixes the saveload bug at long last!

### DIFF
--- a/TheElements-dev/jni/saveload.c
+++ b/TheElements-dev/jni/saveload.c
@@ -440,7 +440,7 @@ char loadStateLogicV1(FILE* fp)
 
                 // Find custom with that hash, and set the index
                 elementIndex = findElementFromHash(elementHash);
-                if (elementIndex)
+                if (elementIndex >= 0)
                 {
                     a_element[tempParticle] = elements[elementIndex];
                 }
@@ -844,8 +844,8 @@ unsigned long hashStr(unsigned char *str)
 }
 // Find an element based on the hash
 // For now, do it stupidly: iterate through customs and hash them,
-// looking for a match.
-unsigned char findElementFromHash(unsigned long hash)
+// looking for a match. If not found, return -1.
+int findElementFromHash(unsigned long hash)
 {
     int i;
     unsigned long tempHash;
@@ -857,4 +857,5 @@ unsigned char findElementFromHash(unsigned long hash)
             return i;
         }
     }
+    return -1;
 }

--- a/TheElements-dev/jni/saveload.h
+++ b/TheElements-dev/jni/saveload.h
@@ -57,6 +57,6 @@ char loadCustomElement(char* loadLoc);
 unsigned long hashElement(struct Element* element);
 char* stringifyElement(struct Element* element);
 unsigned long hashStr(unsigned char* str);
-unsigned char findElementFromHash(unsigned long hash);
+int findElementFromHash(unsigned long hash);
 
 #endif //!SAVELOAD_H_INCLUDED


### PR DESCRIPTION
Saveload bug stacktrace for posterity:

---

Build fingerprint: 'samsung/m3xx/m3:4.3/JSS15J/I9305XXUEML8:user/release-keys'
Revision: '2'
pid: 360, tid: 397, name: Thread-6327 >>> com.idkjava.thelements <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr f6ce756c
r0 65980881 r1 00000000 r2 613d9564 r3 606e5368
r4 6129aee4 r5 4014c39c r6 00000108 r7 00000118
r8 0001829f r9 61b39923 sl 612995d8 fp 00000000
ip 00000001 sp 61b398c8 lr 4010eac1 pc 612940ae cpsr 28000030
d0 3ec0000000002600 d1 7149f2ca3e000000
d2 0100010001000100 d3 0000000000000000
d4 0100010001000100 d5 0000000000000000
d6 42c800003f4ccccd d7 4378000000000069
d8 0000000000000000 d9 0000000000000000
d10 0000000000000000 d11 0000000000000000
d12 0000000000000000 d13 0000000000000000
d14 0000000000000000 d15 0000000000000000
d16 406f000000000000 d17 0100010001000100
d18 0000000000000000 d19 0000000000000000
d20 0000000000000000 d21 0000000000000000
d22 0000000000000000 d23 0000000000000000
d24 0000000000000000 d25 0055000000530000
d26 0000000000000000 d27 0000000000000000
d28 0707070703030303 d29 0002000000020000
d30 0001000000010000 d31 0001000000010000
scr 28000090

backtrace:
#00 pc 000060ae /data/app-lib/com.idkjava.thelements-2/libthelements.so (loadStateLogicV1+681)
#01 pc 000068a7 /data/app-lib/com.idkjava.thelements-2/libthelements.so (loadState+146)
#02 pc 000043c7 /data/app-lib/com.idkjava.thelements-2/libthelements.so (Java_com_idkjava_thelements_game_SandViewRenderer_nativeLoadState+118)
#03 pc 0001e44c /system/lib/libdvm.so (dvmPlatformInvoke+112)
#04 pc 0004e913 /system/lib/libdvm.so (dvmCallJNIMethod(unsigned int const_, JValue_, Method const_, Thread_)+398)
#05 pc 000505c9 /system/lib/libdvm.so (dvmResolveNativeMethod(unsigned int const_, JValue_, Method const_, Thread_)+256)
#06 pc 00027860 /system/lib/libdvm.so
#07 pc 0002bdf8 /system/lib/libdvm.so (dvmInterpret(Thread_, Method const_, JValue*)+184)
#08 pc 00060a89 /system/lib/libdvm.so (dvmCallMethodV(Thread_, Method const_, Object_, bool, JValue_, std::__va_list)+292)
#09 pc 00060ab3 /system/lib/libdvm.so (dvmCallMethod(Thread_, Method const_, Object_, JValue_, ...)+20)
#10 pc 00055823 /system/lib/libdvm.so
#11 pc 0000cb58 /system/lib/libc.so (__thread_entry+72)
#12 pc 0000ccd4 /system/lib/libc.so (pthread_create+208)

code around pc:
6129408c eceaf7fd d1e61c43 46282101 f8cd460a 
6129409c f7fdb014 e7c3ed48 58e24b38 58e34b38 
612940ac f853681b f8cd3020 f842b030 e78c3028 
612940bc e6c39e05 b014f8cd f8dd9f0f 2101b038 
612940cc 460a4628 ed2ef7fd 2a009a0c 59e3d1a8 
612940dc 990b4658 3a01681a 4b2b601a 58e32201 
612940ec 2008f803 58e34b29 f7fe681f f847fafd 
612940fc 9e068020 59a39807 0388eb03 7a00ed93 
6129410c eebd5823 eb037ac7 edd30388 4b1b7a00 
6129411c eefd58e3 ee177ae7 f8530a10 ee172028 
6129412c f7fe1a90 e6c3fe8f ecdef7fd 000070d2 
6129413c 00000128 000058a2 00005898 0000587e 
6129414c 00005870 0000010c 00005742 000058a0 
6129415c 00000150 00005720 00005868 00000118 
6129416c 0000022c 00000168 00000108 00000234 
6129417c 00000214 000001ac 0000579a 000001a0 

code around lr:
4010eaa0 4b03b508 6819447b 4790680a bf00bd08 
4010eab0 0003a558 4b03b508 6819447b 4790684a 
4010eac0 bf00bd08 0003a544 4b03b508 681a447b 
4010ead0 47986893 bf00bd08 0003a530 4b03b508 
4010eae0 681a447b 479868d3 bf00bd08 0003a51c 
4010eaf0 4b03b508 681a447b 47986913 bf00bd08 
4010eb00 0003a508 49094808 4478b508 f0004479 
4010eb10 b140eec2 20064906 44794a06 e8bd447a 
4010eb20 f0044008 bd08bb17 0003b8a6 fffffaad 
4010eb30 00030570 00030862 49094808 4478b508 
4010eb40 f0004479 b140eea8 20064906 44794a06 
4010eb50 e8bd447a f0044008 bd08bafd 0003d0a6 
4010eb60 fffff86d 0003053c 0003085b b09ab570 
4010eb70 a9024d19 447d4b19 682058ec 90194626 
4010eb80 44784817 fd00f01f a802b1e8 fe3ef01c 
4010eb90 b1c04604 ec0af00d 90004912 586a2004 
